### PR TITLE
Fix signature for private bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+0.1.6
+-----
+
+- Fix private bucket `bucket_get_object_share_link` method sometime will got `SignatureDoesNotMatch` bug.

--- a/lib/aliyun/oss/authorization.rb
+++ b/lib/aliyun/oss/authorization.rb
@@ -2,6 +2,7 @@ require 'base64'
 require 'openssl'
 require 'digest'
 require 'json'
+require 'cgi'
 
 module Aliyun
   module Oss
@@ -30,7 +31,7 @@ module Aliyun
       # @return [String]
       def self.get_temporary_signature(secret_key, expire_time, options = {})
         content_string = concat_content_string(options[:verb], expire_time, options)
-        URI.escape(signature(secret_key, content_string).strip)
+        CGI.escape(signature(secret_key, content_string).strip)
       end
 
       # Get base64 encoded string, used to fill policy field

--- a/lib/aliyun/oss/version.rb
+++ b/lib/aliyun/oss/version.rb
@@ -1,5 +1,5 @@
 module Aliyun
   module Oss
-    VERSION = '0.1.5'
+    VERSION = '0.1.6'
   end
 end

--- a/test/aliyun/authorization_test.rb
+++ b/test/aliyun/authorization_test.rb
@@ -54,7 +54,7 @@ describe Aliyun::Oss::Authorization do
       key: 'oss-api.pdf',
       verb: 'GET'
     )
-    assert_equal('EwaNTn1erJGkimiJ9WmXgwnANLc=', temporary_signature)
+    assert_equal('EwaNTn1erJGkimiJ9WmXgwnANLc%3D', temporary_signature)
   end
 
   # Example from https://docs.aliyun.com/#/pub/oss/api-reference/object&PostObject#menu7

--- a/test/aliyun/struct/file_test.rb
+++ b/test/aliyun/struct/file_test.rb
@@ -27,7 +27,7 @@ describe Aliyun::Oss::Struct::File do
   it '#share_link should get share link' do
     Timecop.freeze(Time.parse('2015-11-04 21:59:00 +0000')) do
       expected = 'http://bucket-name.oss-cn-beijing.aliyuncs.com/object-key?' \
-        "OSSAccessKeyId=#{access_key}&Expires=1446677940&Signature=4vOq8+Tnk2ZVBOWYtwu/iYEnUaM="
+        "OSSAccessKeyId=#{access_key}&Expires=1446677940&Signature=4vOq8%2BTnk2ZVBOWYtwu%2FiYEnUaM%3D"
       assert_equal(expected, struct_object.share_link(3600))
     end
   end


### PR DESCRIPTION
阿里云官方文档给出的例子来看，签名字符串是需要 Escape 的：

```
http://oss-example.oss-cn-hangzhou.aliyuncs.com/oss-api.pdf?OSSAccessKeyId=44CF9590006BF252F707&Expires=1141889120&Signature=vjbyPxybdZaNmGa%2ByT272YEAiv4%3D
```

```
Signature=vjbyPxybdZaNmGa%2ByT272YEAiv4%3D
```

而之前用的 `URI.escape` 是不行的，它不会把 `=` 之类的符号进行转义。
